### PR TITLE
Backend - Airports  Bug-fix - Search -  Pagination 

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -28,6 +28,7 @@
     "@nestjs/core": "^11.1.6",
     "@nestjs/graphql": "^13.1.0",
     "@nestjs/platform-express": "^11.1.6",
+    "@prisma/client": "^4.6.1",
     "graphql": "^16.11.0",
     "reflect-metadata": "^0.2.2",
     "rimraf": "^3.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "db:seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
     "@apollo/server": "^4.12.2",

--- a/backend/prisma/migrations/20250928150413_init/migration.sql
+++ b/backend/prisma/migrations/20250928150413_init/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "Airport" (
+    "id" SERIAL NOT NULL,
+    "iata" TEXT NOT NULL,
+    "name" TEXT,
+    "city" TEXT,
+    "country" TEXT,
+    "latitude" DOUBLE PRECISION,
+    "longitude" DOUBLE PRECISION,
+
+    CONSTRAINT "Airport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Airport_iata_key" ON "Airport"("iata");
+
+-- CreateIndex
+CREATE INDEX "Airport_name_idx" ON "Airport"("name");
+
+-- CreateIndex
+CREATE INDEX "Airport_city_idx" ON "Airport"("city");
+
+-- CreateIndex
+CREATE INDEX "Airport_country_idx" ON "Airport"("country");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -9,3 +9,17 @@ datasource db {
   provider = "postgresql"
   url      = env("DATABASE_URL")
 }
+
+model Airport {
+  id        Int     @id @default(autoincrement())
+  iata      String  @unique
+  name      String?    // Nullable
+  city      String?    // Nullable
+  country   String?    // Nullable
+  latitude  Float?     // Nullable
+  longitude Float?     // Nullable
+
+  @@index([name])
+  @@index([city])
+  @@index([country])
+}

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,54 @@
+import { PrismaClient } from '@prisma/client';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as process from 'node:process';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  try {
+    const existingCount = await prisma.airport.count();
+    if (existingCount > 0) {
+      console.log(`Found ${existingCount}`);
+      return;
+    }
+    const airportPath = path.join(__dirname, 'airports.json');
+    if (!fs.existsSync(airportPath)) {
+      throw Error(`Airport ${airportPath} does not exist`);
+    }
+    const airportsData = JSON.parse(fs.readFileSync(airportPath, 'utf8'));
+    console.log(`Found ${airportsData.length} airports from Json`);
+
+    const batchSize = 1000;
+    let processed = 0;
+
+    for (let i = 0; i < airportsData.length; i = i + batchSize) {
+      const batch = airportsData.slice(i, i + batchSize);
+      const airports = batch.map((airport) => ({
+        name: airport.name,
+        iata: airport.iata,
+        city: airport.city,
+        country: airport.country,
+        latitude: airport.latitude,
+        longitude: airport.longitude,
+      }));
+
+      await prisma.airport.createMany({
+        data: airports,
+        skipDuplicates: true,
+      });
+      processed += batch.length;
+    }
+    console.log(`Processed`);
+    console.log(`Total: ${prisma.airport.count()}`);
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+}
+
+main()
+  .catch((e) => console.error(e))
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/airport/airport.graphql
+++ b/backend/src/airport/airport.graphql
@@ -1,0 +1,27 @@
+type Airport {
+  id: Int!
+  iata: String!
+  name: String
+  city: String
+  country: String
+  latitude: Float
+  longitude: Float
+}
+
+type AirportSearchResult {
+  airports: [Airport!]!
+  total: Int!
+  currentPage: Int!
+  totalPages: Int!
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  pageSize: Int!
+}
+
+type Query {
+  searchAirports(
+    search: String
+    skip: Int = 0
+    take: Int = 100
+  ): AirportSearchResult!
+}

--- a/backend/src/airport/airport_service.ts
+++ b/backend/src/airport/airport_service.ts
@@ -1,0 +1,69 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { Airport, AirportSearchResult } from '../graphql';
+
+@Injectable()
+export class AirportService {
+  constructor(private readonly prisma: PrismaService) {
+    console.log('AirportService started with Prisma Service');
+  }
+
+  async searchAirports(args: {
+    search?: string;
+    skip?: number;
+    take?: number;
+  }): Promise<AirportSearchResult> {
+    const search = (args.search ?? '').trim();
+    const skip = Math.max(0, args.skip ?? 0);
+    const take = Math.max(1, args.take ?? 100);
+
+    const where: Prisma.AirportWhereInput = search
+      ? {
+          OR: [
+            { name: { contains: search, mode: 'insensitive' } },
+            { iata: { contains: search, mode: 'insensitive' } },
+            { city: { contains: search, mode: 'insensitive' } },
+            { country: { contains: search, mode: 'insensitive' } },
+          ],
+        }
+      : {};
+
+    // total for pagination
+    const total = await this.prisma.airport.count({ where });
+
+    // page data
+    const airportsDb = await this.prisma.airport.findMany({
+      where,
+      orderBy: { id: 'asc' },
+      skip,
+      take,
+    });
+
+    // map DB entities to your GraphQL type if needed; here they match 1:1
+    const airports: Airport[] = airportsDb.map((a) => ({
+      id: a.id,
+      iata: a.iata,
+      name: a.name ?? null,
+      city: a.city ?? null,
+      country: a.country ?? null,
+      latitude: a.latitude ?? null,
+      longitude: a.longitude ?? null,
+    }));
+
+    const currentPage = Math.floor(skip / take) + 1;
+    const totalPages = total === 0 ? 0 : Math.ceil(total / take);
+    const hasNextPage = skip + take < total;
+    const hasPreviousPage = skip > 0;
+
+    return {
+      airports: airports,
+      total: total,
+      currentPage: currentPage,
+      totalPages: totalPages,
+      hasNextPage: hasNextPage,
+      hasPreviousPage: hasPreviousPage,
+      pageSize: take,
+    };
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,8 @@ import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { join } from 'path';
 import { AppResolver } from './app.resolver';
 import { SeaportResolver } from './seaport.resolver';
+import { PrismaService } from './prisma/prisma.service';
+import { AirportService } from './airport/airport_service';
 
 @Module({
   imports: [
@@ -17,6 +19,12 @@ import { SeaportResolver } from './seaport.resolver';
     }),
   ],
   controllers: [],
-  providers: [AppService, AppResolver, SeaportResolver],
+  providers: [
+    AppService,
+    AppResolver,
+    SeaportResolver,
+    PrismaService,
+    AirportService,
+  ],
 })
 export class AppModule {}

--- a/backend/src/app.resolver.ts
+++ b/backend/src/app.resolver.ts
@@ -1,12 +1,32 @@
-import { Query, Resolver } from '@nestjs/graphql';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { AppService } from './app.service';
+import { AirportSearchResult } from './graphql';
+import { AirportService } from './airport/airport_service';
 
 @Resolver()
 export class AppResolver {
-  constructor(private readonly appService: AppService) {}
+  constructor(
+    private readonly appService: AppService,
+    private readonly airportService: AirportService,
+  ) {}
 
   @Query()
   hello(): string {
     return this.appService.getHello();
+  }
+  @Query('searchAirports')
+  async searchAirports(
+    @Args('search') search?: string,
+    @Args('skip') skip?: number,
+    @Args('take') take?: number,
+  ): Promise<AirportSearchResult> {
+    const safeSkip = skip ?? 0;
+    const safeTake = take ?? 100;
+
+    return this.airportService.searchAirports({
+      search,
+      skip: safeSkip,
+      take: safeTake,
+    });
   }
 }

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 // MOCK DATA
 const locations = [
   { portId: 1, city: 'Hamburg', countryAlpha2: 'DE' },
-  // { portId: 2, city: 'Rotterdam', country: 'Netherlands' },
+  { portId: 2, city: 'Rotterdam', countryAlpha2: 'Netherlands' },
 ];
 
 const seaports = [
@@ -18,11 +18,11 @@ export class AppService {
   }
 
   findSeaportById(id: number) {
-    return seaports.find((port) => port.id === id);
+    return seaports.find((port) => port.id === id) ?? null;
   }
 
   findLocationForPort(portId: number) {
     console.log(`SERVICE: Checking for location of port ${portId}...`);
-    return locations.find((loc) => loc.portId === portId);
+    return locations.find((loc) => loc.portId === portId) ?? null;
   }
 }

--- a/backend/src/graphql.ts
+++ b/backend/src/graphql.ts
@@ -8,7 +8,28 @@
 /* tslint:disable */
 /* eslint-disable */
 
+export interface Airport {
+    id: number;
+    iata: string;
+    name?: Nullable<string>;
+    city?: Nullable<string>;
+    country?: Nullable<string>;
+    latitude?: Nullable<number>;
+    longitude?: Nullable<number>;
+}
+
+export interface AirportSearchResult {
+    airports: Airport[];
+    total: number;
+    currentPage: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    pageSize: number;
+}
+
 export interface IQuery {
+    searchAirports(search?: Nullable<string>, skip?: Nullable<number>, take?: Nullable<number>): AirportSearchResult | Promise<AirportSearchResult>;
     hello(): string | Promise<string>;
     getSeaport(id: number): Nullable<Seaport> | Promise<Nullable<Seaport>>;
 }

--- a/backend/src/graphql.ts
+++ b/backend/src/graphql.ts
@@ -10,13 +10,13 @@
 
 export interface IQuery {
     hello(): string | Promise<string>;
-    getSeaport(id: number): Seaport | Promise<Seaport>;
+    getSeaport(id: number): Nullable<Seaport> | Promise<Nullable<Seaport>>;
 }
 
 export interface Seaport {
     id: number;
     name: string;
-    location: Location;
+    location?: Nullable<Location>;
 }
 
 export interface Location {

--- a/backend/src/prisma/prisma.service.ts
+++ b/backend/src/prisma/prisma.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit(): Promise<void> {
+    await this.$connect();
+  }
+  async onModuleDestroy(): Promise<void> {
+    await this.$disconnect();
+  }
+}

--- a/backend/src/schema.graphql
+++ b/backend/src/schema.graphql
@@ -2,13 +2,13 @@ type Query {
   "A simple query that returns a welcome message"
   hello: String!
 
-  getSeaport(id: Int!): Seaport!
+  getSeaport(id: Int!): Seaport
 }
 
 type Seaport {
   id: Int!
   name: String!
-  location: Location!
+  location: Location
 }
 
 type Location {

--- a/backend/src/seaport.resolver.ts
+++ b/backend/src/seaport.resolver.ts
@@ -14,11 +14,11 @@ export class SeaportResolver {
 
   @Query()
   getSeaport(@Args({ name: 'id', type: () => Int }) id: number) {
-    return this.appService.findSeaportById(id);
+    return this.appService.findSeaportById(id) ?? null;
   }
 
   @ResolveField()
   location(@Parent() seaport: { id: number }) {
-    return this.appService.findLocationForPort(seaport.id);
+    return this.appService.findLocationForPort(seaport.id) ?? null;
   }
 }


### PR DESCRIPTION

Fix the Bug: There is a Seaports resolver added to the backend, but in some edge-cases when searching for specific ports by specifying their IDs (e.g., 1, 2, 3), it throws an error and is unable to resolve anything. Investigate the issue and add a hotfix.
Optimize airports data: Please move this data into a database scheme on the backend.
Add an endpoint: Write an endpoint that allows fetching data from the frontend. Your endpoint should allow user to look up airports by searching for airports by name, IATA, city, or country.
 